### PR TITLE
Shorter name for HACS?

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "Multiscrape - A Home Assistant custom scraping component",
+  "name": "Multiscrape",
   "hacs": "1.6.0",
   "domains": ["sensor", "binary_sensor"],
   "iot_class": "Local Polling",


### PR DESCRIPTION
The name of this custom component in HACS "Multiscrape - A Home Assistant custom scraping component" is very long and redundant - and therefore needs two lines unlike all the other custom components I have, which triggers my OCD ;)
I think "Home Assistant" does not need to be mentioned, since HACS is only for HA. The "custom [...] component" should be clear too, since it's listed in the HACS custom components / integrations list. "Scraping" is already included in "Multiscrape".
Feel free to close this PR if you disagree :)

Anyway, thanks for this great custom component! :)