### PR TITLE
Align pins with HA 2024.1 in manifest.json

### DIFF
--- a/custom_components/multiscrape/manifest.json
+++ b/custom_components/multiscrape/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/danieldotnl/ha-multiscrape",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/danieldotnl/ha-multiscrape/issues",
-  "requirements": ["lxml==4.9.1", "beautifulsoup4==4.11.1"],
+  "requirements": ["beautifulsoup4==4.12.2", "lxml==4.9.4"],
   "version": "6.5.0"
 }


### PR DESCRIPTION
Resolves #301. Tested working on 2024.1.0b3.

Without this change, the integration completely fails to load on 2024.1.