### PR TITLE
Update manifest.json to prevent conflicts with HA (fix for 2024.1)

### DIFF
--- a/custom_components/multiscrape/manifest.json
+++ b/custom_components/multiscrape/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/danieldotnl/ha-multiscrape",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/danieldotnl/ha-multiscrape/issues",
-  "requirements": ["lxml==5.0.0", "beautifulsoup4==4.12.2"],
+  "requirements": ["lxml>=4.9.1", "beautifulsoup4>=4.12.2"],
   "version": "6.5.0"
 }


### PR DESCRIPTION
Changed the package pinning into the suggested `>=` format, so future updates to core package will not break this component - implementing the posts I shared in https://github.com/danieldotnl/ha-multiscrape/issues/301#issuecomment-1873762239

Multiscrape should list the lowest needed version it is compatible with, and let core figure out which package to pick. There could be an upper bound as well, if a newer package is incompatible (i.e.: `lxml` is pinned to below 5.0.0 in HA core right now, as another integration breaks with that version). So if you _need_  a newer version because of a fix, this should be updated. If it isn't needed, you can leave it as is and core will figure out what to do.

Tested locally, works fine again on HA 2024.1. Someone should test for 2023.12.

Fixes #301 