### PR TITLE
Remove requirements pinning in manifest.json

### DIFF
--- a/custom_components/multiscrape/manifest.json
+++ b/custom_components/multiscrape/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/danieldotnl/ha-multiscrape",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/danieldotnl/ha-multiscrape/issues",
-  "requirements": ["lxml>=4.9.1", "beautifulsoup4>=4.12.2"],
+  "requirements": ["lxml", "beautifulsoup4"],
   "version": "6.5.0"
 }


### PR DESCRIPTION
Why are we manually pinning requirements here when we have no control over them? Other popular HACS integrations I am using, such as Waste Collection Schedule, specify the requirement but don't pin these to a particular version. Changing this would avoid issues where the integration breaks on each new HA release.