### PR TITLE
remove `scraping component` from name

### DIFF
--- a/custom_components/multiscrape/manifest.json
+++ b/custom_components/multiscrape/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "multiscrape",
-  "name": "Multiscrape scraping component",
+  "name": "Multiscrape",
   "codeowners": ["@danieldotnl"],
   "config_flow": false,
   "dependencies": [],


### PR DESCRIPTION
Because it's called `Multiscrape` anywhere else and with the new functionality in HA 2024.8 it makes for a very long name on the integrations page

![image](https://github.com/user-attachments/assets/cc30de36-b925-47eb-9b7c-0f365254f60d)
