### PR TITLE
Replace index-based discovery with ScraperRegistry (#554)

### DIFF
--- a/custom_components/multiscrape/__init__.py
+++ b/custom_components/multiscrape/__init__.py
@@ -79,20 +79,22 @@ async def _async_process_config(hass: HomeAssistant, config) -> bool:
     load_tasks = []
     registry: ScraperRegistry = hass.data[DOMAIN]
 
-    for conf in config[DOMAIN]:
+    for scraper_idx, conf in enumerate(config[DOMAIN]):
         config_name = conf.get(CONF_NAME)
         if config_name is None:
             resource = conf.get(CONF_RESOURCE) or ""
-            config_name = f"scraper_{slugify(resource)}" if resource else "scraper_unnamed"
+            config_name = (
+                f"scraper_{slugify(resource)}" if resource else f"scraper_unnamed_{scraper_idx}"
+            )
             _LOGGER.debug(
-                "# Found no name for scraper, generated a unique name: %s", config_name
+                "# Found no name for scraper, generated name: %s", config_name
             )
 
         _LOGGER.debug(
             "%s # Setting up multiscrape with config:\n %s", config_name, conf
         )
 
-        scraper_id = config_name
+        scraper_id = _deduplicate_id(registry, config_name)
 
         file_manager = await create_file_manager(hass, config_name, conf.get(CONF_LOG_RESPONSE))
         session = create_http_session(config_name, conf, hass, file_manager)
@@ -130,7 +132,9 @@ async def _async_process_config(hass: HomeAssistant, config) -> bool:
                 entity_name = platform_conf.get(CONF_NAME, "")
                 entity_key = slugify(entity_name) if entity_name else f"entity_{id(platform_conf)}"
 
-                instance.platform_configs.setdefault(platform_domain, {})[entity_key] = platform_conf
+                platform_dict = instance.platform_configs.setdefault(platform_domain, {})
+                entity_key = _deduplicate_entity_key(platform_dict, entity_key)
+                platform_dict[entity_key] = platform_conf
 
                 load = discovery.async_load_platform(
                     hass,
@@ -149,6 +153,34 @@ async def _async_process_config(hass: HomeAssistant, config) -> bool:
 
 
     return True
+
+
+def _deduplicate_id(registry: ScraperRegistry, base_id: str) -> str:
+    """Return a unique scraper ID, appending a suffix if needed."""
+    if not registry.contains(base_id):
+        return base_id
+    suffix = 2
+    while registry.contains(f"{base_id}_{suffix}"):
+        suffix += 1
+    deduped = f"{base_id}_{suffix}"
+    _LOGGER.warning(
+        "Duplicate scraper name '%s', using '%s' instead", base_id, deduped
+    )
+    return deduped
+
+
+def _deduplicate_entity_key(platform_dict: dict, base_key: str) -> str:
+    """Return a unique entity key within a platform, appending a suffix if needed."""
+    if base_key not in platform_dict:
+        return base_key
+    suffix = 2
+    while f"{base_key}_{suffix}" in platform_dict:
+        suffix += 1
+    deduped = f"{base_key}_{suffix}"
+    _LOGGER.warning(
+        "Duplicate entity name '%s', using '%s' instead", base_key, deduped
+    )
+    return deduped
 
 
 async def async_get_config_and_coordinator(hass, platform_domain, discovery_info):

--- a/custom_components/multiscrape/__init__.py
+++ b/custom_components/multiscrape/__init__.py
@@ -14,13 +14,14 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import discovery
 from homeassistant.helpers.reload import (async_integration_yaml_config,
                                           async_reload_integration_platforms)
+from homeassistant.util import slugify
 
-from .const import (CONF_LOG_RESPONSE, COORDINATOR, DOMAIN, PLATFORM_IDX,
-                    SCRAPER, SCRAPER_DATA, SCRAPER_IDX)
+from .const import CONF_LOG_RESPONSE, DOMAIN, ENTITY_KEY, SCRAPER_ID
 from .coordinator import (create_content_request_manager,
                           create_multiscrape_coordinator)
 from .file import create_file_manager
 from .http_session import create_http_session
+from .registry import ScraperInstance, ScraperRegistry
 from .schema import COMBINED_SCHEMA, CONFIG_SCHEMA  # noqa: F401
 from .scraper import create_scraper
 from .service import setup_config_services, setup_integration_services
@@ -65,8 +66,8 @@ async def async_setup(hass: HomeAssistant, entry: ConfigEntry):
 
 
 def _async_setup_shared_data(hass: HomeAssistant):
-    """Create shared data for platform config and scraper coordinators."""
-    hass.data[DOMAIN] = {key: [] for key in [SCRAPER_DATA, *PLATFORMS]}
+    """Create a fresh ScraperRegistry for platform config and scraper coordinators."""
+    hass.data[DOMAIN] = ScraperRegistry()
 
 
 async def _async_process_config(hass: HomeAssistant, config) -> bool:
@@ -76,11 +77,13 @@ async def _async_process_config(hass: HomeAssistant, config) -> bool:
 
     refresh_tasks = []
     load_tasks = []
+    registry: ScraperRegistry = hass.data[DOMAIN]
 
-    for scraper_idx, conf in enumerate(config[DOMAIN]):
+    for conf in config[DOMAIN]:
         config_name = conf.get(CONF_NAME)
         if config_name is None:
-            config_name = f"Scraper_noname_{scraper_idx}"
+            resource = conf.get(CONF_RESOURCE) or ""
+            config_name = f"scraper_{slugify(resource)}" if resource else "scraper_unnamed"
             _LOGGER.debug(
                 "# Found no name for scraper, generated a unique name: %s", config_name
             )
@@ -88,6 +91,8 @@ async def _async_process_config(hass: HomeAssistant, config) -> bool:
         _LOGGER.debug(
             "%s # Setting up multiscrape with config:\n %s", config_name, conf
         )
+
+        scraper_id = config_name
 
         file_manager = await create_file_manager(hass, config_name, conf.get(CONF_LOG_RESPONSE))
         session = create_http_session(config_name, conf, hass, file_manager)
@@ -108,9 +113,12 @@ async def _async_process_config(hass: HomeAssistant, config) -> bool:
 
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _shutdown_session)
 
-        hass.data[DOMAIN][SCRAPER_DATA].append(
-            {SCRAPER: scraper, COORDINATOR: coordinator}
+        instance = ScraperInstance(
+            scraper_id=scraper_id,
+            scraper=scraper,
+            coordinator=coordinator,
         )
+        registry.register(instance)
 
         await setup_config_services(hass, coordinator, config_name)
 
@@ -119,14 +127,16 @@ async def _async_process_config(hass: HomeAssistant, config) -> bool:
                 continue
 
             for platform_conf in conf[platform_domain]:
-                hass.data[DOMAIN][platform_domain].append(platform_conf)
-                platform_idx = len(hass.data[DOMAIN][platform_domain]) - 1
+                entity_name = platform_conf.get(CONF_NAME, "")
+                entity_key = slugify(entity_name) if entity_name else f"entity_{id(platform_conf)}"
+
+                instance.platform_configs.setdefault(platform_domain, {})[entity_key] = platform_conf
 
                 load = discovery.async_load_platform(
                     hass,
                     platform_domain,
                     DOMAIN,
-                    {SCRAPER_IDX: scraper_idx, PLATFORM_IDX: platform_idx},
+                    {SCRAPER_ID: scraper_id, ENTITY_KEY: entity_key},
                     config,
                 )
                 load_tasks.append(load)
@@ -143,8 +153,7 @@ async def _async_process_config(hass: HomeAssistant, config) -> bool:
 
 async def async_get_config_and_coordinator(hass, platform_domain, discovery_info):
     """Get the config and coordinator for the platform from discovery."""
-    shared_data = hass.data[DOMAIN][SCRAPER_DATA][discovery_info[SCRAPER_IDX]]
-    conf = hass.data[DOMAIN][platform_domain][discovery_info[PLATFORM_IDX]]
-    coordinator = shared_data[COORDINATOR]
-    scraper = shared_data[SCRAPER]
-    return conf, coordinator, scraper
+    registry: ScraperRegistry = hass.data[DOMAIN]
+    instance = registry.get(discovery_info[SCRAPER_ID])
+    conf = instance.platform_configs[platform_domain][discovery_info[ENTITY_KEY]]
+    return conf, instance.coordinator, instance.scraper

--- a/custom_components/multiscrape/const.py
+++ b/custom_components/multiscrape/const.py
@@ -40,13 +40,8 @@ DEFAULT_EXTRACT = "text"
 
 CONF_FIELDS = "fields"
 
-SCRAPER_IDX = "scraper_idx"
-PLATFORM_IDX = "platform_idx"
-
-COORDINATOR = "coordinator"
-SCRAPER = "scraper"
-
-SCRAPER_DATA = "scraper"
+SCRAPER_ID = "scraper_id"
+ENTITY_KEY = "entity_key"
 
 METHODS = ["POST", "GET", "PUT"]
 DEFAULT_SEPARATOR = ","

--- a/custom_components/multiscrape/registry.py
+++ b/custom_components/multiscrape/registry.py
@@ -3,19 +3,24 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from homeassistant.const import Platform
+
+if TYPE_CHECKING:
+    from .coordinator import MultiscrapeDataUpdateCoordinator
+    from .scraper import Scraper
 
 _LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
 class ScraperInstance:
-    """Holds all data for a single scraper configuration."""
+    """Hold all data for a single scraper configuration."""
 
     scraper_id: str
-    scraper: object
-    coordinator: object
+    scraper: Scraper
+    coordinator: MultiscrapeDataUpdateCoordinator
     platform_configs: dict[Platform, dict[str, dict]] = field(default_factory=dict)
 
 
@@ -25,6 +30,10 @@ class ScraperRegistry:
     def __init__(self):
         """Initialize an empty registry."""
         self._scrapers: dict[str, ScraperInstance] = {}
+
+    def contains(self, scraper_id: str) -> bool:
+        """Check if a scraper ID is already registered."""
+        return scraper_id in self._scrapers
 
     def register(self, instance: ScraperInstance) -> None:
         """Register a scraper instance by its unique ID."""

--- a/custom_components/multiscrape/registry.py
+++ b/custom_components/multiscrape/registry.py
@@ -1,0 +1,48 @@
+"""ScraperRegistry for type-safe, reload-safe scraper lookup."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from homeassistant.const import Platform
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class ScraperInstance:
+    """Holds all data for a single scraper configuration."""
+
+    scraper_id: str
+    scraper: object
+    coordinator: object
+    platform_configs: dict[Platform, dict[str, dict]] = field(default_factory=dict)
+
+
+class ScraperRegistry:
+    """Registry for scraper instances, replacing index-based lookups."""
+
+    def __init__(self):
+        """Initialize an empty registry."""
+        self._scrapers: dict[str, ScraperInstance] = {}
+
+    def register(self, instance: ScraperInstance) -> None:
+        """Register a scraper instance by its unique ID."""
+        if instance.scraper_id in self._scrapers:
+            raise ValueError(
+                f"Scraper '{instance.scraper_id}' is already registered"
+            )
+        self._scrapers[instance.scraper_id] = instance
+        _LOGGER.debug("Registered scraper: %s", instance.scraper_id)
+
+    def get(self, scraper_id: str) -> ScraperInstance:
+        """Get a scraper instance by its unique ID."""
+        return self._scrapers[scraper_id]
+
+    def get_all(self) -> list[ScraperInstance]:
+        """Get all registered scraper instances."""
+        return list(self._scrapers.values())
+
+    def clear(self) -> None:
+        """Remove all registered scrapers."""
+        self._scrapers.clear()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -12,9 +12,8 @@ from custom_components.multiscrape import (_async_process_config,
                                            _async_setup_shared_data,
                                            async_get_config_and_coordinator,
                                            async_setup)
-from custom_components.multiscrape.const import (COORDINATOR, DOMAIN,
-                                                 PLATFORM_IDX, SCRAPER,
-                                                 SCRAPER_DATA, SCRAPER_IDX)
+from custom_components.multiscrape.const import DOMAIN, ENTITY_KEY, SCRAPER_ID
+from custom_components.multiscrape.registry import ScraperRegistry
 
 
 @pytest.fixture
@@ -47,18 +46,13 @@ def empty_config():
 @pytest.mark.async_test
 @pytest.mark.timeout(10)
 async def test_async_setup_shared_data(hass: HomeAssistant):
-    """Test _async_setup_shared_data creates required data structures."""
+    """Test _async_setup_shared_data creates a ScraperRegistry."""
     # Act
     _async_setup_shared_data(hass)
 
     # Assert
     assert DOMAIN in hass.data
-    assert SCRAPER_DATA in hass.data[DOMAIN]
-    assert Platform.SENSOR in hass.data[DOMAIN]
-    assert Platform.BINARY_SENSOR in hass.data[DOMAIN]
-    assert Platform.BUTTON in hass.data[DOMAIN]
-    assert isinstance(hass.data[DOMAIN][SCRAPER_DATA], list)
-    assert isinstance(hass.data[DOMAIN][Platform.SENSOR], list)
+    assert isinstance(hass.data[DOMAIN], ScraperRegistry)
 
 
 @pytest.mark.integration
@@ -119,10 +113,11 @@ async def test_async_process_config_creates_scraper_data(
 
     # Assert
     assert result is True
-    assert len(hass.data[DOMAIN][SCRAPER_DATA]) == 1
-    scraper_data = hass.data[DOMAIN][SCRAPER_DATA][0]
-    assert SCRAPER in scraper_data
-    assert COORDINATOR in scraper_data
+    registry: ScraperRegistry = hass.data[DOMAIN]
+    assert len(registry.get_all()) == 1
+    instance = registry.get("test_scraper")
+    assert instance.scraper is not None
+    assert instance.coordinator is not None
 
 
 @pytest.mark.integration
@@ -154,8 +149,11 @@ async def test_async_process_config_generates_name_for_unnamed_scraper(
 
     # Assert
     assert result is True
-    # Should have generated a name like "Scraper_noname_0"
-    assert len(hass.data[DOMAIN][SCRAPER_DATA]) == 1
+    registry: ScraperRegistry = hass.data[DOMAIN]
+    assert len(registry.get_all()) == 1
+    # Should have generated an ID from the resource URL
+    instance = registry.get_all()[0]
+    assert "example" in instance.scraper_id
 
 
 @pytest.mark.integration
@@ -191,9 +189,11 @@ async def test_async_process_config_stores_platform_configs(
     await _async_process_config(hass, minimal_config)
 
     # Assert
-    assert len(hass.data[DOMAIN][Platform.SENSOR]) == 1
-    sensor_config = hass.data[DOMAIN][Platform.SENSOR][0]
-    assert sensor_config[CONF_NAME] == "test_sensor"
+    registry: ScraperRegistry = hass.data[DOMAIN]
+    instance = registry.get("test_scraper")
+    sensor_configs = instance.platform_configs[Platform.SENSOR]
+    assert len(sensor_configs) == 1
+    assert list(sensor_configs.values())[0][CONF_NAME] == "test_sensor"
 
 
 @pytest.mark.integration
@@ -234,9 +234,10 @@ async def test_async_process_config_with_multiple_platforms(hass: HomeAssistant)
     await _async_process_config(hass, config)
 
     # Assert
-    assert len(hass.data[DOMAIN][Platform.SENSOR]) == 1
-    assert len(hass.data[DOMAIN][Platform.BINARY_SENSOR]) == 1
-    assert len(hass.data[DOMAIN][Platform.BUTTON]) == 1
+    instance = hass.data[DOMAIN].get("multi_platform_scraper")
+    assert len(instance.platform_configs[Platform.SENSOR]) == 1
+    assert len(instance.platform_configs[Platform.BINARY_SENSOR]) == 1
+    assert len(instance.platform_configs[Platform.BUTTON]) == 1
 
 
 @pytest.mark.integration
@@ -267,8 +268,10 @@ async def test_async_process_config_with_multiple_sensors_per_scraper(
     await _async_process_config(hass, config)
 
     # Assert
-    assert len(hass.data[DOMAIN][Platform.SENSOR]) == 3
-    assert len(hass.data[DOMAIN][SCRAPER_DATA]) == 1  # Only one scraper
+    registry: ScraperRegistry = hass.data[DOMAIN]
+    instance = registry.get("multi_sensor_scraper")
+    assert len(instance.platform_configs[Platform.SENSOR]) == 3
+    assert len(registry.get_all()) == 1  # Only one scraper
 
 
 @pytest.mark.integration
@@ -298,8 +301,10 @@ async def test_async_process_config_with_multiple_scrapers(hass: HomeAssistant):
     await _async_process_config(hass, config)
 
     # Assert
-    assert len(hass.data[DOMAIN][SCRAPER_DATA]) == 2
-    assert len(hass.data[DOMAIN][Platform.SENSOR]) == 2
+    registry: ScraperRegistry = hass.data[DOMAIN]
+    assert len(registry.get_all()) == 2
+    assert registry.get("scraper1").platform_configs[Platform.SENSOR].get("sensor1") is not None
+    assert registry.get("scraper2").platform_configs[Platform.SENSOR].get("sensor2") is not None
     # Each scraper should have its own trigger service
     assert hass.services.has_service(DOMAIN, "trigger_scraper1")
     assert hass.services.has_service(DOMAIN, "trigger_scraper2")
@@ -315,7 +320,7 @@ async def test_async_get_config_and_coordinator(hass: HomeAssistant, minimal_con
     _async_setup_shared_data(hass)
     await _async_process_config(hass, minimal_config)
 
-    discovery_info = {SCRAPER_IDX: 0, PLATFORM_IDX: 0}
+    discovery_info = {SCRAPER_ID: "test_scraper", ENTITY_KEY: "test_sensor"}
 
     # Act
     conf, coordinator, scraper = await async_get_config_and_coordinator(
@@ -362,7 +367,8 @@ async def test_async_process_config_with_form_submit(hass: HomeAssistant):
 
     # Assert
     assert result is True
-    assert len(hass.data[DOMAIN][SCRAPER_DATA]) == 1
+    registry: ScraperRegistry = hass.data[DOMAIN]
+    assert len(registry.get_all()) == 1
 
 
 @pytest.mark.integration
@@ -395,7 +401,8 @@ async def test_async_process_config_with_resource_template(hass: HomeAssistant):
 
     # Assert
     assert result is True
-    assert len(hass.data[DOMAIN][SCRAPER_DATA]) == 1
+    registry: ScraperRegistry = hass.data[DOMAIN]
+    assert len(registry.get_all()) == 1
 
 
 @pytest.mark.integration
@@ -426,6 +433,7 @@ async def test_async_process_config_skips_platforms_not_in_config(hass: HomeAssi
     await _async_process_config(hass, config)
 
     # Assert
-    assert len(hass.data[DOMAIN][Platform.SENSOR]) == 1
-    assert len(hass.data[DOMAIN][Platform.BINARY_SENSOR]) == 0
-    assert len(hass.data[DOMAIN][Platform.BUTTON]) == 0
+    instance = hass.data[DOMAIN].get("sensor_only_scraper")
+    assert len(instance.platform_configs.get(Platform.SENSOR, {})) == 1
+    assert len(instance.platform_configs.get(Platform.BINARY_SENSOR, {})) == 0
+    assert len(instance.platform_configs.get(Platform.BUTTON, {})) == 0

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -437,3 +437,70 @@ async def test_async_process_config_skips_platforms_not_in_config(hass: HomeAssi
     assert len(instance.platform_configs.get(Platform.SENSOR, {})) == 1
     assert len(instance.platform_configs.get(Platform.BINARY_SENSOR, {})) == 0
     assert len(instance.platform_configs.get(Platform.BUTTON, {})) == 0
+
+
+@pytest.mark.integration
+@pytest.mark.async_test
+@pytest.mark.timeout(10)
+@pytest.mark.respx
+async def test_duplicate_scraper_names_are_deduplicated(hass: HomeAssistant):
+    """Test that duplicate scraper names get a suffix instead of crashing."""
+    # Arrange
+    _async_setup_shared_data(hass)
+    config = {
+        DOMAIN: [
+            {
+                CONF_NAME: "my_scraper",
+                CONF_RESOURCE: "https://example.com/1",
+                Platform.SENSOR: [{CONF_NAME: "sensor1", "select": ".v1"}],
+            },
+            {
+                CONF_NAME: "my_scraper",
+                CONF_RESOURCE: "https://example.com/2",
+                Platform.SENSOR: [{CONF_NAME: "sensor2", "select": ".v2"}],
+            },
+        ]
+    }
+
+    # Act
+    result = await _async_process_config(hass, config)
+
+    # Assert - both scrapers should be registered with distinct IDs
+    assert result is True
+    registry: ScraperRegistry = hass.data[DOMAIN]
+    assert len(registry.get_all()) == 2
+    assert registry.get("my_scraper") is not None
+    assert registry.get("my_scraper_2") is not None
+
+
+@pytest.mark.integration
+@pytest.mark.async_test
+@pytest.mark.timeout(10)
+@pytest.mark.respx
+async def test_duplicate_entity_names_are_deduplicated(hass: HomeAssistant):
+    """Test that duplicate entity names within a scraper get a suffix."""
+    # Arrange
+    _async_setup_shared_data(hass)
+    config = {
+        DOMAIN: [
+            {
+                CONF_NAME: "my_scraper",
+                CONF_RESOURCE: "https://example.com",
+                Platform.SENSOR: [
+                    {CONF_NAME: "temperature", "select": ".temp1"},
+                    {CONF_NAME: "temperature", "select": ".temp2"},
+                ],
+            }
+        ]
+    }
+
+    # Act
+    await _async_process_config(hass, config)
+
+    # Assert - both sensors should be stored with distinct keys
+    registry: ScraperRegistry = hass.data[DOMAIN]
+    instance = registry.get("my_scraper")
+    sensor_configs = instance.platform_configs[Platform.SENSOR]
+    assert len(sensor_configs) == 2
+    assert "temperature" in sensor_configs
+    assert "temperature_2" in sensor_configs

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -87,3 +87,10 @@ def test_platform_configs_access(registry, make_instance):
 
     retrieved = registry.get("my_scraper")
     assert retrieved.platform_configs[Platform.SENSOR]["temp_sensor"] is sensor_config
+
+
+def test_contains(registry, make_instance):
+    """Test contains checks for registered IDs."""
+    assert registry.contains("my_scraper") is False
+    registry.register(make_instance("my_scraper"))
+    assert registry.contains("my_scraper") is True

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,89 @@
+"""Tests for the ScraperRegistry."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.const import Platform
+
+from custom_components.multiscrape.registry import (ScraperInstance,
+                                                    ScraperRegistry)
+
+
+@pytest.fixture
+def registry():
+    """Create a fresh ScraperRegistry."""
+    return ScraperRegistry()
+
+
+@pytest.fixture
+def make_instance():
+    """Create ScraperInstance objects for testing."""
+    def _make(scraper_id="test_scraper", platform_configs=None):
+        return ScraperInstance(
+            scraper_id=scraper_id,
+            scraper=MagicMock(),
+            coordinator=MagicMock(),
+            platform_configs=platform_configs or {},
+        )
+    return _make
+
+
+def test_register_and_get(registry, make_instance):
+    """Test registering and retrieving a scraper instance."""
+    instance = make_instance("my_scraper")
+    registry.register(instance)
+    assert registry.get("my_scraper") is instance
+
+
+def test_get_missing_raises_key_error(registry):
+    """Test that getting a missing scraper raises KeyError."""
+    with pytest.raises(KeyError):
+        registry.get("nonexistent")
+
+
+def test_register_duplicate_raises_value_error(registry, make_instance):
+    """Test that registering a duplicate ID raises ValueError."""
+    registry.register(make_instance("dup"))
+    with pytest.raises(ValueError, match="already registered"):
+        registry.register(make_instance("dup"))
+
+
+def test_get_all(registry, make_instance):
+    """Test get_all returns all registered instances."""
+    a = make_instance("a")
+    b = make_instance("b")
+    registry.register(a)
+    registry.register(b)
+
+    result = registry.get_all()
+    assert len(result) == 2
+    assert a in result
+    assert b in result
+
+
+def test_get_all_empty(registry):
+    """Test get_all on empty registry returns empty list."""
+    assert registry.get_all() == []
+
+
+def test_clear(registry, make_instance):
+    """Test clear removes all registered instances."""
+    registry.register(make_instance("a"))
+    registry.register(make_instance("b"))
+    registry.clear()
+    assert registry.get_all() == []
+
+
+def test_platform_configs_access(registry, make_instance):
+    """Test accessing platform configs through the instance."""
+    sensor_config = {"name": "temp_sensor", "select": ".temp"}
+    instance = make_instance(
+        "my_scraper",
+        platform_configs={
+            Platform.SENSOR: {"temp_sensor": sensor_config},
+        },
+    )
+    registry.register(instance)
+
+    retrieved = registry.get("my_scraper")
+    assert retrieved.platform_configs[Platform.SENSOR]["temp_sensor"] is sensor_config


### PR DESCRIPTION
## Summary
- Replace fragile array-index lookups (`SCRAPER_IDX`/`PLATFORM_IDX`) with a type-safe `ScraperRegistry` using deterministic string IDs derived from config names
- Scraper/entity lookup is now reload-safe since order no longer matters
- Duplicate scraper names and entity names are automatically deduplicated with `_2`, `_3` suffixes and a warning log

## Changes
- **New**: `registry.py` — `ScraperInstance` dataclass and `ScraperRegistry` class
- **Modified**: `__init__.py` — uses registry instead of dict-of-lists; discovery passes string IDs
- **Modified**: `const.py` — removed `SCRAPER_IDX`/`PLATFORM_IDX`/`SCRAPER_DATA`, added `SCRAPER_ID`/`ENTITY_KEY`
- **New**: `test_registry.py` — unit tests for registry operations
- **Modified**: `test_init.py` — updated for registry-based lookups, added duplicate-name tests
- **No changes** to `sensor.py`, `binary_sensor.py`, `button.py` (they pass discovery_info through without inspecting it)

## Test plan
- [x] All 317 tests pass (including 3 new deduplication tests)
- [ ] Manual test with HA: configure two scrapers, reload, verify entities map to correct scrapers
- [ ] Manual test: configure duplicate scraper names, verify warning logged and both work

Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-generated naming for scrapers without explicit names, now using slugified resources or numeric fallbacks instead of generic labels.

* **Improvements**
  * Enhanced deduplication of scraper configurations for improved stability and uniqueness handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->