### PR TITLE
Improve test coverage for schema and HTTP session (#556)

### DIFF
--- a/tests/test_http_session.py
+++ b/tests/test_http_session.py
@@ -1,6 +1,5 @@
 """Tests for the unified HttpSession class."""
 
-from unittest.mock import MagicMock
 
 import httpx
 import pytest
@@ -83,15 +82,6 @@ def session(hass: HomeAssistant, http_config):
         http_config=http_config,
         file_manager=None,
     )
-
-
-@pytest.fixture
-def mock_file_manager():
-    """Create a mock file manager."""
-    mock = MagicMock()
-    mock.write = MagicMock()
-    mock.empty_folder = MagicMock()
-    return mock
 
 
 @pytest.fixture
@@ -1765,3 +1755,384 @@ async def test_e2e_form_variables_empty_when_no_variables_configured(
         assert request_manager.form_variables == {}
     finally:
         await session.async_close()
+
+
+# ============================================================================
+# End-to-End Full Variable Propagation Chain Tests
+# ============================================================================
+
+
+def _make_e2e_form_conf(hass):
+    """Create a config with form_submit + variables for e2e tests."""
+    from homeassistant.helpers.template import Template
+
+    return {
+        "resource": "https://site.com/data",
+        "method": "get",
+        "verify_ssl": True,
+        "timeout": 10,
+        "parser": "html.parser",
+        "form_submit": {
+            "resource": "https://site.com/login",
+            "select": "#loginform",
+            "input": {"username": "admin", "password": "secret"},
+            "input_filter": [],
+            "submit_once": False,
+            "resubmit_on_error": False,
+            "variables": [
+                {
+                    "name": "api_token",
+                    "select": Template(".api-token", hass),
+                    "extract": "text",
+                },
+            ],
+            "method": "get",
+            "verify_ssl": True,
+            "timeout": 10,
+            "parser": "html.parser",
+            "separator": ",",
+        },
+    }
+
+
+@pytest.mark.integration
+@pytest.mark.async_test
+@pytest.mark.timeout(10)
+@respx.mock
+async def test_e2e_full_variable_chain_form_to_scraper_output(hass: HomeAssistant):
+    """End-to-end: form variables flow through the full chain to scraper output.
+
+    Tests the complete flow:
+    FormAuthenticator.scrape_variables() → session.form_variables →
+    coordinator.scrape_context → Scraper.scrape(context=) → template rendering
+    """
+    from homeassistant.helpers.template import Template
+
+    from custom_components.multiscrape.coordinator import \
+        create_content_request_manager
+    from custom_components.multiscrape.scraper import Scraper
+    from custom_components.multiscrape.selector import Selector
+
+    conf = _make_e2e_form_conf(hass)
+
+    session = create_http_session("chain_test", conf, hass, None)
+
+    try:
+        respx.get("https://site.com/login").mock(
+            return_value=respx.MockResponse(200, text=LOGIN_PAGE_WITH_TOKEN_HTML)
+        )
+        respx.post("https://site.com/auth/submit").mock(
+            return_value=respx.MockResponse(200, text=LOGIN_PAGE_WITH_TOKEN_HTML)
+        )
+        data_html = """
+        <html><body>
+        <div class="temperature">21.5</div>
+        </body></html>
+        """
+        respx.get("https://site.com/data").mock(
+            return_value=respx.MockResponse(200, text=data_html)
+        )
+
+        request_manager = create_content_request_manager(
+            "chain_test", conf, hass, session
+        )
+
+        # Step 1: get_content triggers form auth + page fetch
+        content = await request_manager.get_content()
+
+        # Step 2: Variables were scraped from form response
+        assert session.form_variables["api_token"] == "scraped_token_123"
+
+        # Step 3: Build scrape context (as coordinator does)
+        scrape_context = ScrapeContext(form_variables=request_manager.form_variables)
+        assert scrape_context.form_variables["api_token"] == "scraped_token_123"
+
+        # Step 4: Scraper uses context in value template
+        scraper = Scraper("chain_test", hass, None, "html.parser", ",")
+        await scraper.set_content(content)
+        selector = Selector(hass, {
+            "select": Template(".temperature", hass),
+            "extract": "text",
+            "value_template": Template("{{ value }}°C (auth={{ api_token }})", hass),
+        })
+        result = scraper.scrape(selector, "temp_sensor", context=scrape_context)
+
+        # Final: form variable appears in rendered output
+        assert result == "21.5°C (auth=scraped_token_123)"
+    finally:
+        await session.async_close()
+
+
+@pytest.mark.integration
+@pytest.mark.async_test
+@pytest.mark.timeout(10)
+@respx.mock
+async def test_e2e_variables_passed_to_params_renderer(hass: HomeAssistant):
+    """End-to-end: form variables are passed to params renderer during page request."""
+    received_params_vars = {}
+
+    def params_renderer(variables={}, parse_result=None):
+        received_params_vars.update(variables)
+        return {"token": variables.get("api_token", "")}
+
+    conf = _make_e2e_form_conf(hass)
+
+    session = create_http_session("params_test", conf, hass, None)
+    session._http_config.params_renderer = params_renderer
+
+    try:
+        respx.get("https://site.com/login").mock(
+            return_value=respx.MockResponse(200, text=LOGIN_PAGE_WITH_TOKEN_HTML)
+        )
+        respx.post("https://site.com/auth/submit").mock(
+            return_value=respx.MockResponse(200, text=LOGIN_PAGE_WITH_TOKEN_HTML)
+        )
+        respx.get(url__startswith="https://site.com/data").mock(
+            return_value=respx.MockResponse(200, text=TARGET_PAGE_HTML)
+        )
+
+        from custom_components.multiscrape.coordinator import \
+            create_content_request_manager
+
+        request_manager = create_content_request_manager(
+            "params_test", conf, hass, session
+        )
+        await request_manager.get_content()
+
+        # Verify form variables were passed to the params renderer
+        assert received_params_vars.get("api_token") == "scraped_token_123"
+    finally:
+        await session.async_close()
+
+
+@pytest.mark.integration
+@pytest.mark.async_test
+@pytest.mark.timeout(10)
+@respx.mock
+async def test_e2e_variables_passed_to_data_renderer(hass: HomeAssistant):
+    """End-to-end: form variables are passed to data renderer during page request."""
+    received_data_vars = {}
+
+    def data_renderer(variables={}, parse_result=None):
+        received_data_vars.update(variables)
+        return None
+
+    conf = _make_e2e_form_conf(hass)
+
+    session = create_http_session("data_rend_test", conf, hass, None)
+    session._http_config.data_renderer = data_renderer
+
+    try:
+        respx.get("https://site.com/login").mock(
+            return_value=respx.MockResponse(200, text=LOGIN_PAGE_WITH_TOKEN_HTML)
+        )
+        respx.post("https://site.com/auth/submit").mock(
+            return_value=respx.MockResponse(200, text=LOGIN_PAGE_WITH_TOKEN_HTML)
+        )
+        respx.get("https://site.com/data").mock(
+            return_value=respx.MockResponse(200, text=TARGET_PAGE_HTML)
+        )
+
+        from custom_components.multiscrape.coordinator import \
+            create_content_request_manager
+
+        request_manager = create_content_request_manager(
+            "data_rend_test", conf, hass, session
+        )
+        await request_manager.get_content()
+
+        # Verify form variables were passed to the data renderer
+        assert received_data_vars.get("api_token") == "scraped_token_123"
+    finally:
+        await session.async_close()
+
+
+# ============================================================================
+# Error-Path File Logging Tests
+# ============================================================================
+
+
+@pytest.mark.integration
+@pytest.mark.async_test
+@pytest.mark.http
+@pytest.mark.timeout(10)
+@respx.mock
+async def test_handle_request_exception_with_none_response(
+    session_with_file_manager, mock_file_manager
+):
+    """Test _handle_request_exception is safe when response is None.
+
+    When a connection fails before any response is received (e.g., DNS failure),
+    _handle_request_exception is called with response=None. It must not crash.
+    """
+    url = "https://example.com/unreachable"
+    respx.get(url).mock(side_effect=RequestError("DNS resolution failed"))
+
+    with pytest.raises(RequestError):
+        await session_with_file_manager.async_request("test", url)
+
+    # File manager should have logged request headers/body before the error,
+    # but NOT error response (since response is None)
+    write_calls = mock_file_manager.write.call_args_list
+    filenames = [call[0][0] for call in write_calls]
+    assert any("request_headers" in f for f in filenames)
+    assert not any("response_headers_error" in f for f in filenames)
+    assert not any("response_body_error" in f for f in filenames)
+
+
+@pytest.mark.integration
+@pytest.mark.async_test
+@pytest.mark.http
+@pytest.mark.timeout(10)
+@respx.mock
+async def test_handle_request_exception_timeout_with_none_response(
+    session_with_file_manager, mock_file_manager
+):
+    """Test _handle_request_exception handles timeout with no response."""
+    url = "https://example.com/slow"
+    respx.get(url).mock(side_effect=TimeoutException("Timed out"))
+
+    with pytest.raises(TimeoutException):
+        await session_with_file_manager.async_request("test", url)
+
+    write_calls = mock_file_manager.write.call_args_list
+    filenames = [call[0][0] for call in write_calls]
+    # No error response files since response is None
+    assert not any("response_headers_error" in f for f in filenames)
+    assert not any("response_body_error" in f for f in filenames)
+
+
+@pytest.mark.integration
+@pytest.mark.async_test
+@pytest.mark.http
+@pytest.mark.timeout(10)
+@respx.mock
+async def test_file_logging_error_response_files_on_http_error(
+    session_with_file_manager, mock_file_manager
+):
+    """Test that HTTP errors (4xx/5xx) log error response headers and body."""
+    url = "https://example.com/server-error"
+    respx.get(url).mock(
+        return_value=respx.MockResponse(500, text="Internal Server Error")
+    )
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await session_with_file_manager.async_request("test_ctx", url)
+
+    write_calls = mock_file_manager.write.call_args_list
+    filenames = [call[0][0] for call in write_calls]
+    # Should have request files and response files (logged before raise)
+    # plus error response files (logged in _handle_request_exception)
+    assert any("test_ctx_request_headers" in f for f in filenames)
+    assert any("test_ctx_response_headers" in f for f in filenames)
+    assert any("test_ctx_response_body" in f for f in filenames)
+    assert any("test_ctx_response_headers_error" in f for f in filenames)
+    assert any("test_ctx_response_body_error" in f for f in filenames)
+
+
+@pytest.mark.integration
+@pytest.mark.async_test
+@pytest.mark.http
+@pytest.mark.timeout(10)
+async def test_async_file_log_skips_none_content(
+    hass: HomeAssistant, mock_file_manager
+):
+    """Test _async_file_log does nothing when content is None."""
+    config = make_http_config()
+    sess = HttpSession(
+        config_name="test", hass=hass, http_config=config,
+        file_manager=mock_file_manager,
+    )
+
+    await sess._async_file_log("test_content", "ctx", None)
+
+    # write should not be called when content is None
+    mock_file_manager.write.assert_not_called()
+
+
+@pytest.mark.integration
+@pytest.mark.async_test
+@pytest.mark.http
+@pytest.mark.timeout(10)
+async def test_async_file_log_handles_write_exception(
+    hass: HomeAssistant, mock_file_manager, caplog
+):
+    """Test _async_file_log logs error when file write fails."""
+    mock_file_manager.write.side_effect = OSError("Disk full")
+
+    config = make_http_config()
+    sess = HttpSession(
+        config_name="test_session", hass=hass, http_config=config,
+        file_manager=mock_file_manager,
+    )
+
+    # Should not raise — exception is caught and logged
+    await sess._async_file_log("test_content", "ctx", "some data")
+
+    assert "Unable to write" in caplog.text
+
+
+@pytest.mark.integration
+@pytest.mark.async_test
+@pytest.mark.http
+@pytest.mark.timeout(10)
+async def test_async_file_log_correct_filename(
+    hass: HomeAssistant, mock_file_manager
+):
+    """Test _async_file_log generates correct filename from context and content_name."""
+    config = make_http_config()
+    sess = HttpSession(
+        config_name="test", hass=hass, http_config=config,
+        file_manager=mock_file_manager,
+    )
+
+    await sess._async_file_log("response_headers", "page", {"Content-Type": "text/html"})
+
+    mock_file_manager.write.assert_called_once()
+    call_args = mock_file_manager.write.call_args[0]
+    assert call_args[0] == "page_response_headers.txt"
+    assert call_args[1] == {"Content-Type": "text/html"}
+
+
+# ============================================================================
+# create_http_session with variables=None edge case
+# ============================================================================
+
+
+@pytest.mark.integration
+@pytest.mark.async_test
+@pytest.mark.timeout(10)
+async def test_create_http_session_form_variables_none(hass: HomeAssistant):
+    """Test create_http_session handles form config where variables key is absent.
+
+    When config.get(CONF_FORM_VARIABLES) returns None (key missing from config),
+    the `if variables:` check in create_http_session must not crash.
+    """
+    conf = {
+        "resource": "https://example.com",
+        "method": "get",
+        "verify_ssl": True,
+        "timeout": 10,
+        "parser": "html.parser",
+        "form_submit": {
+            "resource": "https://example.com/login",
+            "select": "#login",
+            "input": {"user": "admin"},
+            "input_filter": [],
+            "submit_once": False,
+            "resubmit_on_error": True,
+            # "variables" key deliberately omitted — config.get() returns None
+            "method": "post",
+            "verify_ssl": True,
+            "timeout": 10,
+        },
+    }
+    session = create_http_session("none_vars_test", conf, hass, None)
+
+    assert session._form_authenticator is not None
+    # No scraper should be created when variables is None/empty
+    assert session._form_authenticator._config.variables_selectors == {}
+    assert session._form_authenticator._config.scraper is None
+    assert session.form_variables == {}
+
+    await session.async_close()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2,27 +2,42 @@
 
 import pytest
 import voluptuous as vol
-from homeassistant.const import (CONF_AUTHENTICATION, CONF_METHOD,
+from homeassistant.const import (CONF_AUTHENTICATION, CONF_FORCE_UPDATE,
+                                 CONF_ICON, CONF_METHOD, CONF_NAME,
                                  CONF_RESOURCE, CONF_RESOURCE_TEMPLATE,
-                                 CONF_TIMEOUT, CONF_VERIFY_SSL,
-                                 HTTP_BASIC_AUTHENTICATION,
+                                 CONF_SCAN_INTERVAL, CONF_TIMEOUT,
+                                 CONF_UNIQUE_ID, CONF_VALUE_TEMPLATE,
+                                 CONF_VERIFY_SSL, HTTP_BASIC_AUTHENTICATION,
                                  HTTP_DIGEST_AUTHENTICATION)
 
 from custom_components.multiscrape.const import (CONF_EXTRACT,
                                                  CONF_FORM_VARIABLES,
+                                                 CONF_LOG_RESPONSE,
                                                  CONF_ON_ERROR_LOG,
                                                  CONF_ON_ERROR_VALUE,
                                                  CONF_ON_ERROR_VALUE_DEFAULT,
                                                  CONF_ON_ERROR_VALUE_LAST,
                                                  CONF_ON_ERROR_VALUE_NONE,
-                                                 CONF_SELECT, DEFAULT_EXTRACT,
-                                                 DOMAIN, LOG_ERROR)
-from custom_components.multiscrape.schema import (COMBINED_SCHEMA,
+                                                 CONF_PARSER, CONF_SELECT,
+                                                 CONF_SEPARATOR,
+                                                 DEFAULT_BINARY_SENSOR_NAME,
+                                                 DEFAULT_BUTTON_NAME,
+                                                 DEFAULT_EXTRACT,
+                                                 DEFAULT_FORCE_UPDATE,
+                                                 DEFAULT_PARSER,
+                                                 DEFAULT_SENSOR_NAME,
+                                                 DEFAULT_SEPARATOR, DOMAIN,
+                                                 LOG_ERROR)
+from custom_components.multiscrape.schema import (BINARY_SENSOR_SCHEMA,
+                                                  BUTTON_SCHEMA,
+                                                  COMBINED_SCHEMA,
                                                   CONFIG_SCHEMA,
                                                   FORM_SUBMIT_SCHEMA,
                                                   ON_ERROR_SCHEMA,
                                                   SELECTOR_SCHEMA,
-                                                  SERVICE_COMBINED_SCHEMA)
+                                                  SENSOR_SCHEMA,
+                                                  SERVICE_COMBINED_SCHEMA,
+                                                  create_service_schema)
 from custom_components.multiscrape.scraper import DEFAULT_TIMEOUT
 
 # ============================================================================
@@ -283,3 +298,268 @@ def test_form_schema_defaults():
     assert result["input_filter"] == []
     assert result["submit_once"] is False
     assert result["resubmit_on_error"] is True
+
+
+@pytest.mark.unit
+def test_form_schema_rejects_variables_without_name():
+    """Test that variables entries require a 'name' field."""
+    with pytest.raises(vol.Invalid):
+        _validate_form({
+            CONF_FORM_VARIABLES: [
+                {CONF_SELECT: "input[name='csrf']"},
+            ],
+        })
+
+
+# ============================================================================
+# INTEGRATION_SCHEMA defaults tests
+# ============================================================================
+
+
+@pytest.mark.unit
+def test_integration_schema_default_parser():
+    """Test that omitting parser defaults to DEFAULT_PARSER ('lxml')."""
+    result = _validate_combined({CONF_RESOURCE: "https://example.com"})
+    assert result[CONF_PARSER] == DEFAULT_PARSER
+    assert result[CONF_PARSER] == "lxml"
+
+
+@pytest.mark.unit
+def test_integration_schema_default_log_response():
+    """Test that log_response defaults to False."""
+    result = _validate_combined({CONF_RESOURCE: "https://example.com"})
+    assert result[CONF_LOG_RESPONSE] is False
+
+
+@pytest.mark.unit
+def test_integration_schema_default_separator():
+    """Test that separator defaults to DEFAULT_SEPARATOR (',')."""
+    result = _validate_combined({CONF_RESOURCE: "https://example.com"})
+    assert result[CONF_SEPARATOR] == DEFAULT_SEPARATOR
+    assert result[CONF_SEPARATOR] == ","
+
+
+@pytest.mark.unit
+def test_integration_schema_scan_interval_optional():
+    """Test that scan_interval is optional and not set by default."""
+    result = _validate_combined({CONF_RESOURCE: "https://example.com"})
+    assert CONF_SCAN_INTERVAL not in result
+
+
+@pytest.mark.unit
+def test_integration_schema_name_optional():
+    """Test that name is optional and not set by default."""
+    result = _validate_combined({CONF_RESOURCE: "https://example.com"})
+    assert CONF_NAME not in result
+
+
+@pytest.mark.unit
+def test_integration_schema_custom_parser():
+    """Test that a custom parser value is accepted."""
+    result = _validate_combined({
+        CONF_RESOURCE: "https://example.com",
+        CONF_PARSER: "html.parser",
+    })
+    assert result[CONF_PARSER] == "html.parser"
+
+
+# ============================================================================
+# SENSOR_SCHEMA / BINARY_SENSOR_SCHEMA / BUTTON_SCHEMA defaults tests
+# ============================================================================
+
+
+def _validate_sensor(config):
+    """Validate a sensor config."""
+    return vol.Schema(SENSOR_SCHEMA)(config)
+
+
+def _validate_binary_sensor(config):
+    """Validate a binary_sensor config."""
+    return vol.Schema(BINARY_SENSOR_SCHEMA)(config)
+
+
+def _validate_button(config):
+    """Validate a button config."""
+    return vol.Schema(BUTTON_SCHEMA)(config)
+
+
+@pytest.mark.unit
+def test_sensor_schema_defaults():
+    """Test sensor schema default values."""
+    result = _validate_sensor({})
+    assert result[CONF_NAME] == DEFAULT_SENSOR_NAME
+    assert result[CONF_FORCE_UPDATE] == DEFAULT_FORCE_UPDATE
+    assert result[CONF_FORCE_UPDATE] is False
+    assert result[CONF_EXTRACT] == DEFAULT_EXTRACT
+
+
+@pytest.mark.unit
+def test_binary_sensor_schema_defaults():
+    """Test binary_sensor schema default values."""
+    result = _validate_binary_sensor({})
+    assert result[CONF_NAME] == DEFAULT_BINARY_SENSOR_NAME
+    assert result[CONF_FORCE_UPDATE] is False
+    assert result[CONF_EXTRACT] == DEFAULT_EXTRACT
+
+
+@pytest.mark.unit
+def test_button_schema_defaults():
+    """Test button schema default values."""
+    result = _validate_button({})
+    assert result[CONF_NAME] == DEFAULT_BUTTON_NAME
+
+
+@pytest.mark.unit
+def test_sensor_schema_optional_fields():
+    """Test that sensor optional fields (unique_id, unit, etc.) are not set by default."""
+    result = _validate_sensor({})
+    assert CONF_UNIQUE_ID not in result
+    assert "unit_of_measurement" not in result
+    assert "device_class" not in result
+    assert "state_class" not in result
+    assert "picture" not in result
+
+
+@pytest.mark.unit
+def test_http_schema_rejects_negative_timeout():
+    """Test that negative timeout values are rejected.
+
+    Note: cv.positive_int in HA accepts 0 (it's really non-negative),
+    so timeout=0 is valid at the schema level.
+    """
+    with pytest.raises(vol.Invalid):
+        _validate_combined({
+            CONF_RESOURCE: "https://example.com",
+            CONF_TIMEOUT: -1,
+        })
+
+
+@pytest.mark.unit
+def test_on_error_schema_rejects_invalid_log_level():
+    """Test that invalid log levels are rejected."""
+    with pytest.raises(vol.Invalid):
+        _validate_on_error({CONF_ON_ERROR_LOG: "debug"})
+
+    with pytest.raises(vol.Invalid):
+        _validate_on_error({CONF_ON_ERROR_LOG: "critical"})
+
+
+# ============================================================================
+# create_service_schema() structural tests
+# ============================================================================
+
+
+@pytest.mark.unit
+def test_service_schema_is_vol_schema():
+    """Test that create_service_schema() returns a vol.Schema."""
+    schema = create_service_schema()
+    assert isinstance(schema, vol.Schema)
+
+
+@pytest.mark.unit
+def test_service_schema_inherits_integration_defaults():
+    """Test that service schema inherits INTEGRATION_SCHEMA defaults."""
+    result = SERVICE_COMBINED_SCHEMA({
+        CONF_RESOURCE: "https://example.com",
+    })
+    assert result[CONF_PARSER] == DEFAULT_PARSER
+    assert result[CONF_METHOD] == "get"
+    assert result[CONF_VERIFY_SSL] is True
+
+
+@pytest.mark.unit
+def test_service_schema_binary_sensor_accepts_string_templates():
+    """Test service schema accepts plain strings for binary_sensor templates."""
+    result = SERVICE_COMBINED_SCHEMA({
+        CONF_RESOURCE: "https://example.com",
+        "binary_sensor": [{
+            "name": "test",
+            CONF_SELECT: ".status",
+            CONF_VALUE_TEMPLATE: "{{ value == 'on' }}",
+            CONF_ICON: "mdi:check",
+        }],
+    })
+    assert result["binary_sensor"][0][CONF_VALUE_TEMPLATE] == "{{ value == 'on' }}"
+    assert result["binary_sensor"][0][CONF_ICON] == "mdi:check"
+
+
+@pytest.mark.unit
+def test_service_schema_sensor_attributes_accept_string_value_template():
+    """Test service schema accepts string value_template in sensor attributes."""
+    result = SERVICE_COMBINED_SCHEMA({
+        CONF_RESOURCE: "https://example.com",
+        "sensor": [{
+            "name": "test",
+            CONF_SELECT: ".data",
+            "attributes": [{
+                "name": "detail",
+                CONF_SELECT: ".detail",
+                CONF_VALUE_TEMPLATE: "{{ value | int }}",
+            }],
+        }],
+    })
+    assert result["sensor"][0]["attributes"][0][CONF_VALUE_TEMPLATE] == "{{ value | int }}"
+
+
+@pytest.mark.unit
+def test_service_schema_idempotent():
+    """Test that calling create_service_schema() multiple times returns equivalent schemas."""
+    schema1 = create_service_schema()
+    schema2 = create_service_schema()
+    # Both should accept the same input
+    config = {CONF_RESOURCE: "https://example.com"}
+    result1 = schema1(config)
+    result2 = schema2(config)
+    assert result1 == result2
+
+
+# ============================================================================
+# COMBINED_SCHEMA entity type tests
+# ============================================================================
+
+
+@pytest.mark.unit
+def test_combined_schema_accepts_binary_sensor():
+    """Test COMBINED_SCHEMA accepts binary_sensor config."""
+    result = _validate_combined({
+        CONF_RESOURCE: "https://example.com",
+        "binary_sensor": [{"name": "test", CONF_SELECT: ".status"}],
+    })
+    assert len(result["binary_sensor"]) == 1
+
+
+@pytest.mark.unit
+def test_combined_schema_accepts_button():
+    """Test COMBINED_SCHEMA accepts button config."""
+    result = _validate_combined({
+        CONF_RESOURCE: "https://example.com",
+        "button": [{"name": "refresh"}],
+    })
+    assert len(result["button"]) == 1
+
+
+@pytest.mark.unit
+def test_combined_schema_accepts_all_entity_types():
+    """Test COMBINED_SCHEMA accepts sensor, binary_sensor, and button together."""
+    result = _validate_combined({
+        CONF_RESOURCE: "https://example.com",
+        "sensor": [{"name": "temp", CONF_SELECT: ".temp"}],
+        "binary_sensor": [{"name": "status", CONF_SELECT: ".status"}],
+        "button": [{"name": "refresh"}],
+    })
+    assert len(result["sensor"]) == 1
+    assert len(result["binary_sensor"]) == 1
+    assert len(result["button"]) == 1
+
+
+@pytest.mark.unit
+def test_combined_schema_accepts_no_entities():
+    """Test COMBINED_SCHEMA accepts config with no entity definitions.
+
+    Entity presence is not enforced at schema level — the integration
+    simply creates no entities, which is valid for a config-only entry.
+    """
+    result = _validate_combined({
+        CONF_RESOURCE: "https://example.com",
+    })
+    assert CONF_RESOURCE in result


### PR DESCRIPTION
## Summary
- Adds 29 new tests covering gaps identified in issue #556
- Schema validation: defaults, negative timeout rejection, invalid log level, form variables without name, service schema structure (string templates, idempotency)
- HTTP session: end-to-end form variable chain (form auth → scrape context → template rendering), error-path file logging (None response, write exceptions, dual error files on HTTP 500), `create_http_session` with missing variables key
- Extracts shared e2e config into `_make_e2e_form_conf()` helper and removes duplicate `mock_file_manager` fixture

## Test plan
- [x] All 349 tests pass (`pytest -x -q`)
- [x] Pre-commit hooks pass (ruff, isort, codespell, prettier)

Closes #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded integration test coverage for form authentication, variable propagation, and cookie handling scenarios.
  * Enhanced validation tests for configuration schemas and defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->