### PR TITLE
Promote JsonDetector to JsonParser with lazy pretty-print

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Multiscrape
 
 ---
+
 > [!TIP]
+>
 > ## 👋 A quick note
 >
 > I run **[Smart Home Newsletter](https://smarthomenewsletter.com/?utm_source=github&utm_medium=readme&utm_campaign=multiscrape)** — a weekly curated digest for smart home enthusiasts.
@@ -11,9 +13,8 @@
 > Since you're here, you're clearly into home automation — so you might genuinely enjoy the newsletter.
 >
 > 👉 [Subscribe at smarthomenewsletter.com](https://smarthomenewsletter.com/?utm_source=github&utm_medium=readme&utm_campaign=multiscrape)
->
----
 
+---
 
 [![GitHub Release][releases-shield]][releases]
 [![License][license-shield]](LICENSE)
@@ -33,11 +34,12 @@
 ## Need help with Multiscrape?
 
 ### Personal (paid) support option
+
 I very often get asked for help, for example with finding the right CSS selectors or with a login. Actually more often than I can handle, so I'm running an experiment with a paid support option!
 
 **Sponsor me [here](https://github.com/sponsors/danieldotnl/sponsorships?tier_id=432422), and I'll try to assist you with your `multiscrape` configuration within 1-2 days.** The support funds will go towards family time, making up for the hours I spend on Home Assistant ☺️.
 
-**Note:** Scraping isn't always possible. I'd love to offer a "no cure, no pay" service, but GitHub Sponsoring doesn't support that. If you're concerned about sponsoring without guarentee, please reach out by email before sponsoring!
+**Note:** Scraping isn't always possible. I'd love to offer a "no cure, no pay" service, but GitHub Sponsoring doesn't support that. If you're concerned about sponsoring without guarantee, please reach out by email before sponsoring!
 
 ### Other options
 
@@ -67,7 +69,8 @@ It is based on both the existing [Rest sensor](https://www.home-assistant.io/int
 Install via HACS (default store) or install manually by copying the files in a new 'custom_components/multiscrape' directory.
 
 ## Example configuration (YAML)
-*This code example is to be placed into /config/configuration.yaml*
+
+_This code example is to be placed into /config/configuration.yaml_
 
 ```yaml
 multiscrape:
@@ -100,17 +103,21 @@ multiscrape:
             select: ".release-date"
             attribute: href
 ```
+
 ### Advanced Example Configuration (YAML)
+
 For background on splitting the HA configuration, see the [HA Documentation](https://www.home-assistant.io/docs/configuration/splitting_configuration/).
 
-*Inside the configuration.yaml file*
+_Inside the configuration.yaml file_
+
 ```yaml
 multiscrape: !include multiscrape.yaml
 ```
 
 Make a new file named /config/multiscrape.yaml
 
-*Inside the multiscrape.yaml file. Syntax is the same but starting at the resource level*
+_Inside the multiscrape.yaml file. Syntax is the same but starting at the resource level_
+
 ```yaml
 - resource: https://www.home-assistant.io
   scan_interval: 3600
@@ -145,28 +152,28 @@ Make a new file named /config/multiscrape.yaml
 
 Based on latest (pre) release.
 
-| name              | description                                                                                                               | required | default | type            |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------- | -------- | ------- | --------------- |
-| name              | The name for the integration.                                                                                             | False    |         | string          |
-| resource          | The url for retrieving the site or a template that will output an url. Not required when `resource_template` is provided. | True     |         | string          |
-| resource_template | A template that will output an url after being rendered. Only required when `resource` is not provided.                   | True     |         | template        |
-| authentication    | Configure HTTP authentication. `basic` or `digest`. Use this with username and password fields.                           | False    |         | string          |
-| username          | The username for accessing the url.                                                                                       | False    |         | string          |
-| password          | The password for accessing the url.                                                                                       | False    |         | string          |
-| headers           | The headers for the requests.                                                                                             | False    |         | template - list |
-| params            | The query params for the requests.                                                                                        | False    |         | template - list |
-| method            | The method for the request. Either `POST` or `GET`.                                                                       | False    | GET     | string          |
+| name              | description                                                                                                               | required | default | type              |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------- | -------- | ------- | ----------------- |
+| name              | The name for the integration.                                                                                             | False    |         | string            |
+| resource          | The url for retrieving the site or a template that will output an url. Not required when `resource_template` is provided. | True     |         | string            |
+| resource_template | A template that will output an url after being rendered. Only required when `resource` is not provided.                   | True     |         | template          |
+| authentication    | Configure HTTP authentication. `basic` or `digest`. Use this with username and password fields.                           | False    |         | string            |
+| username          | The username for accessing the url.                                                                                       | False    |         | string            |
+| password          | The password for accessing the url.                                                                                       | False    |         | string            |
+| headers           | The headers for the requests.                                                                                             | False    |         | template - list   |
+| params            | The query params for the requests.                                                                                        | False    |         | template - list   |
+| method            | The method for the request. Either `POST` or `GET`.                                                                       | False    | GET     | string            |
 | payload           | Optional payload to send with a POST request.                                                                             | False    |         | template - string |
-| verify_ssl        | Verify the SSL certificate of the endpoint.                                                                               | False    | True    | boolean         |
-| log_response      | Log the HTTP responses and HTML parsed by BeautifulSoup in files. (Will be written to/config/multiscrape/name_of_config)  | False    | False   | boolean         |
-| timeout           | Defines max time to wait data from the endpoint.                                                                          | False    | 10      | int             |
-| scan_interval     | Determines how often the url will be requested.                                                                           | False    | 60      | int             |
-| parser            | Determines the parser to be used with beautifulsoup. `lxml-xml` for xml recommended and `lxml` for everything else.       | False    | lxml    | string          |
-| list_separator    | Separator to be used in combination with `select_list` features.                                                          | False    | ,       | string          |
-| form_submit       | See [Form-submit](#form-submit)                                                                                           | False    |         |                 |
-| sensor            | See [Sensor](#sensorbinary-sensor)                                                                                        | False    |         | list            |
-| binary_sensor     | See [Binary sensor](#sensorbinary-sensor)                                                                                 | False    |         | list            |
-| button            | See [Refresh button](#refresh-button)                                                                                     | False    |         | list            |
+| verify_ssl        | Verify the SSL certificate of the endpoint.                                                                               | False    | True    | boolean           |
+| log_response      | Log the HTTP responses and HTML parsed by BeautifulSoup in files. (Will be written to/config/multiscrape/name_of_config)  | False    | False   | boolean           |
+| timeout           | Defines max time to wait data from the endpoint.                                                                          | False    | 10      | int               |
+| scan_interval     | Determines how often the url will be requested.                                                                           | False    | 60      | int               |
+| parser            | Determines the parser to be used with beautifulsoup. `lxml-xml` for xml recommended and `lxml` for everything else.       | False    | lxml    | string            |
+| list_separator    | Separator to be used in combination with `select_list` features.                                                          | False    | ,       | string            |
+| form_submit       | See [Form-submit](#form-submit)                                                                                           | False    |         |                   |
+| sensor            | See [Sensor](#sensorbinary-sensor)                                                                                        | False    |         | list              |
+| binary_sensor     | See [Binary sensor](#sensorbinary-sensor)                                                                                 | False    |         | list              |
+| button            | See [Refresh button](#refresh-button)                                                                                     | False    |         | list              |
 
 ### Sensor/Binary Sensor
 
@@ -273,7 +280,7 @@ Configure what should happen in case of a scraping error (the css selector does 
 For each multiscrape instance, a service will be created to trigger a scrape run through an automation. (For manual triggering, the button entity can now be configured.)
 The services are named `multiscrape.trigger_{name of integration}`.
 
-Multiscrape also offers a `get_content` and a `scrape` service. `get_content` retrieves the content of the website you want to scrape. It shows the same data for which you now need to enable `log_response` and open the page_soup.txt file.\
+Multiscrape also offers a `get_content` and a `scrape` service. `get_content` retrieves the content of the website you want to scrape. It shows the same data for which you now need to enable `log_response` and open the `page_soup.txt` file (or `page_json.txt` when the response is JSON).\
 `scrape` does what it says. It scrapes a website and provides the sensors and attributes.
 
 Both services accept the same configuration as what you would provide in your configuration yaml (what is described above), with a small but important caveat: if the service input contains templates, those are automatically parsed by home assistant when the service is being called. That is fine for templates like `resource` and `select`, but templates that need to be applied on the scraped data itself (like `value_template`), cannot be parsed when the service is called. Therefore you need to slightly alter the syntax and add a `!` in the middle. E.g. `{{` becomes `{!{` and `%}` becomes `%!}`. Multiscrape will then understand that this string needs to handled as a template after the service has been called.\

--- a/custom_components/multiscrape/parsers.py
+++ b/custom_components/multiscrape/parsers.py
@@ -1,6 +1,8 @@
 """Content parsers for multiscrape using the Strategy pattern."""
+
 from __future__ import annotations
 
+import json
 import logging
 from abc import ABC, abstractmethod
 from typing import Any
@@ -55,8 +57,13 @@ class HtmlParser(ContentParser):
         )
 
 
-class JsonDetector(ContentParser):
-    """Detects JSON content. Does not parse it (JSON uses value_template only)."""
+class JsonParser(ContentParser):
+    """Parse JSON content into a Python structure.
+
+    Values are typically extracted via Jinja value_template (the canonical
+    Home Assistant pattern); the parsed structure is used for pretty-printing
+    and file logging.
+    """
 
     @property
     def name(self) -> str:
@@ -68,9 +75,9 @@ class JsonDetector(ContentParser):
         content_stripped = content.lstrip() if content else ""
         return bool(content_stripped) and content_stripped[0] in ("{", "[")
 
-    async def parse(self, content: str, hass: Any) -> None:
-        """JSON is not parsed into a queryable structure."""
-        return None
+    async def parse(self, content: str, hass: Any) -> dict | list:
+        """Parse JSON content. Raises json.JSONDecodeError on malformed input."""
+        return await hass.async_add_executor_job(json.loads, content)
 
 
 class ParserFactory:
@@ -79,7 +86,7 @@ class ParserFactory:
     def __init__(self, parser_name: str):
         """Initialize with the HTML parser name."""
         self._parsers: list[ContentParser] = [
-            JsonDetector(),
+            JsonParser(),
             HtmlParser(parser_name),
         ]
 

--- a/custom_components/multiscrape/scraper.py
+++ b/custom_components/multiscrape/scraper.py
@@ -1,11 +1,13 @@
 """Support for multiscrape requests."""
+
+import json
 import logging
 
 from bs4 import BeautifulSoup
 
 from .const import CONF_PARSER, CONF_SEPARATOR
 from .extractors import ValueExtractor
-from .parsers import JsonDetector, ParserFactory
+from .parsers import JsonParser, ParserFactory
 from .scrape_context import ScrapeContext
 
 DEFAULT_TIMEOUT = 10
@@ -64,9 +66,17 @@ class Scraper:
 
     @property
     def formatted_content(self):
-        """Property for getting the content. HTML will be prettified."""
+        """Return the content for display: HTML prettified, JSON pretty-printed, or raw."""
         if self._soup:
             return self._soup.prettify()
+        if self._is_json and self._data:
+            try:
+                return json.dumps(
+                    json.loads(self._data), indent=2, ensure_ascii=False
+                )
+            except (json.JSONDecodeError, RecursionError):
+                # Detected as JSON-shaped but unparsable — fall back to raw.
+                return self._data
         return self._data
 
     async def set_content(self, content):
@@ -74,12 +84,14 @@ class Scraper:
         self._data = content
         parser = self._parser_factory.get_parser(content)
 
-        if isinstance(parser, JsonDetector):
+        if isinstance(parser, JsonParser):
             _LOGGER.debug(
-                "%s # Response seems to be json. Skip parsing with BeautifulSoup.",
+                "%s # Response detected as JSON; skipping BeautifulSoup parsing.",
                 self._config_name,
             )
             self._is_json = True
+            if self._file_manager:
+                await self._async_file_log("page_json", self.formatted_content)
             return
 
         try:
@@ -101,7 +113,9 @@ class Scraper:
             )
             raise
 
-    def scrape(self, selector, sensor, attribute=None, context: ScrapeContext | None = None):
+    def scrape(
+        self, selector, sensor, attribute=None, context: ScrapeContext | None = None
+    ):
         """Scrape based on given selector the data."""
         if context is None:
             context = ScrapeContext.empty()
@@ -123,16 +137,14 @@ class Scraper:
         value = self._extract_value(selector, log_prefix)
 
         if value is not None and selector.value_template is not None:
-            _LOGGER.debug(
-                "%s # Applying value_template on selector result", log_prefix)
+            _LOGGER.debug("%s # Applying value_template on selector result", log_prefix)
             render_ctx = context.with_current_value(value)
             value = selector.value_template.async_render(
                 variables=render_ctx.to_template_variables(), parse_result=True
             )
 
         _LOGGER.debug(
-            "%s # Final selector value: %s of type %s", log_prefix, value, type(
-                value)
+            "%s # Final selector value: %s of type %s", log_prefix, value, type(value)
         )
         return value
 
@@ -140,8 +152,7 @@ class Scraper:
         """Delegate extraction to ValueExtractor."""
         if selector.is_list:
             tags = self._soup.select(selector.list)
-            _LOGGER.debug("%s # List selector selected tags: %s",
-                          log_prefix, tags)
+            _LOGGER.debug("%s # List selector selected tags: %s", log_prefix, tags)
             return self._extractor.extract_list(tags, selector)
         else:
             tag = self._soup.select_one(selector.element)

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,57 +1,80 @@
 """Unit tests for the parsers module."""
 
+import json
+
 import pytest
 from bs4 import BeautifulSoup
 from homeassistant.core import HomeAssistant
 
-from custom_components.multiscrape.parsers import (HtmlParser, JsonDetector,
+from custom_components.multiscrape.parsers import (HtmlParser, JsonParser,
                                                    ParserFactory)
 
+from .fixtures.json_samples import (SAMPLE_JSON_INVALID,
+                                    SAMPLE_JSON_SPECIAL_CHARS)
+
 # ============================================================================
-# JsonDetector tests
+# JsonParser tests
 # ============================================================================
 
 
-class TestJsonDetector:
-    """Tests for JsonDetector."""
+class TestJsonParser:
+    """Tests for JsonParser."""
 
     def setup_method(self):
         """Set up test fixtures."""
-        self.detector = JsonDetector()
+        self.parser = JsonParser()
 
     def test_name(self):
-        """Test that JsonDetector reports its name as 'json'."""
-        assert self.detector.name == "json"
+        """Test that JsonParser reports its name as 'json'."""
+        assert self.parser.name == "json"
 
     def test_can_parse_json_object(self):
         """Test that JSON objects are detected."""
-        assert self.detector.can_parse('{"key": "value"}') is True
+        assert self.parser.can_parse('{"key": "value"}') is True
 
     def test_can_parse_json_array(self):
         """Test that JSON arrays are detected."""
-        assert self.detector.can_parse('[1, 2, 3]') is True
+        assert self.parser.can_parse("[1, 2, 3]") is True
 
     def test_can_parse_json_with_leading_whitespace(self):
         """Test that JSON with leading whitespace is detected."""
-        assert self.detector.can_parse('  {"key": "value"}') is True
+        assert self.parser.can_parse('  {"key": "value"}') is True
 
     def test_cannot_parse_html(self):
         """Test that HTML content is not detected as JSON."""
-        assert self.detector.can_parse("<html><body>Hello</body></html>") is False
+        assert self.parser.can_parse("<html><body>Hello</body></html>") is False
 
     def test_cannot_parse_empty_string(self):
         """Test that empty string is not detected as JSON."""
-        assert self.detector.can_parse("") is False
+        assert self.parser.can_parse("") is False
 
     def test_cannot_parse_plain_text(self):
         """Test that plain text is not detected as JSON."""
-        assert self.detector.can_parse("Hello world") is False
+        assert self.parser.can_parse("Hello world") is False
 
     @pytest.mark.async_test
-    async def test_parse_returns_none(self, hass: HomeAssistant):
-        """Test that parse returns None since JSON is not parsed."""
-        result = await self.detector.parse('{"key": "value"}', hass)
-        assert result is None
+    async def test_parse_returns_dict_for_json_object(self, hass: HomeAssistant):
+        """Test that parse returns a dict for JSON objects."""
+        result = await self.parser.parse('{"key": "value"}', hass)
+        assert result == {"key": "value"}
+
+    @pytest.mark.async_test
+    async def test_parse_returns_list_for_json_array(self, hass: HomeAssistant):
+        """Test that parse returns a list for JSON arrays."""
+        result = await self.parser.parse("[1, 2, 3]", hass)
+        assert result == [1, 2, 3]
+
+    @pytest.mark.async_test
+    async def test_parse_raises_on_malformed_json(self, hass: HomeAssistant):
+        """Test that parse raises JSONDecodeError on malformed input."""
+        with pytest.raises(json.JSONDecodeError):
+            await self.parser.parse(SAMPLE_JSON_INVALID, hass)
+
+    @pytest.mark.async_test
+    async def test_parse_handles_special_chars(self, hass: HomeAssistant):
+        """Test that parse handles JSON with escaped special characters."""
+        result = await self.parser.parse(SAMPLE_JSON_SPECIAL_CHARS, hass)
+        assert result == {"text": 'Text with "quotes" and \n newlines'}
 
 
 # ============================================================================
@@ -88,7 +111,7 @@ class TestHtmlParser:
 
     def test_cannot_parse_json_array(self):
         """Test that JSON arrays are not accepted as HTML."""
-        assert self.parser.can_parse('[1, 2, 3]') is False
+        assert self.parser.can_parse("[1, 2, 3]") is False
 
     @pytest.mark.async_test
     async def test_parse_returns_beautifulsoup(self, hass: HomeAssistant):
@@ -117,15 +140,15 @@ class TestParserFactory:
         """Set up test fixtures."""
         self.factory = ParserFactory("lxml")
 
-    def test_selects_json_detector_for_json_object(self):
-        """Test that factory selects JsonDetector for JSON objects."""
+    def test_selects_json_parser_for_json_object(self):
+        """Test that factory selects JsonParser for JSON objects."""
         parser = self.factory.get_parser('{"key": "value"}')
-        assert isinstance(parser, JsonDetector)
+        assert isinstance(parser, JsonParser)
 
-    def test_selects_json_detector_for_json_array(self):
-        """Test that factory selects JsonDetector for JSON arrays."""
-        parser = self.factory.get_parser('[1, 2, 3]')
-        assert isinstance(parser, JsonDetector)
+    def test_selects_json_parser_for_json_array(self):
+        """Test that factory selects JsonParser for JSON arrays."""
+        parser = self.factory.get_parser("[1, 2, 3]")
+        assert isinstance(parser, JsonParser)
 
     def test_selects_html_parser_for_html(self):
         """Test that factory selects HtmlParser for HTML content."""

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -5,6 +5,7 @@ to extract data from HTML content using CSS selectors.
 """
 
 import re
+from unittest.mock import MagicMock
 
 import pytest
 from homeassistant.core import HomeAssistant
@@ -18,7 +19,8 @@ from custom_components.multiscrape.selector import Selector
 from .fixtures.html_samples import (SAMPLE_HTML_EMPTY, SAMPLE_HTML_FULL,
                                     SAMPLE_HTML_LIST, SAMPLE_HTML_MALFORMED,
                                     SAMPLE_HTML_SPECIAL_TAGS)
-from .fixtures.json_samples import SAMPLE_JSON_SIMPLE
+from .fixtures.json_samples import (SAMPLE_JSON_INVALID, SAMPLE_JSON_NESTED,
+                                    SAMPLE_JSON_SIMPLE)
 
 
 @pytest.fixture
@@ -147,13 +149,15 @@ async def test_scraper_selector_not_found_raises_error(
 @pytest.mark.async_test
 @pytest.mark.timeout(5)
 async def test_scraper_handles_json_content(hass: HomeAssistant, scraper_instance):
-    """Test that scraper detects and handles JSON content correctly."""
+    """Test that scraper detects JSON content and preserves it for value_template."""
     # Arrange
     await scraper_instance.set_content(SAMPLE_JSON_SIMPLE)
 
     # JSON content should not be parsed by BeautifulSoup
     assert scraper_instance._soup is None
+    # Raw data is preserved for value_template (the canonical HA JSON path)
     assert scraper_instance._data == SAMPLE_JSON_SIMPLE
+    assert scraper_instance._is_json is True
 
 
 @pytest.mark.integration
@@ -184,8 +188,8 @@ async def test_scraper_json_without_value_template_raises_error(
 @pytest.mark.async_test
 @pytest.mark.timeout(5)
 async def test_scraper_reset_clears_content(hass: HomeAssistant, scraper_instance):
-    """Test that reset() clears both data and soup."""
-    # Arrange
+    """Test that reset() clears HTML soup and JSON state."""
+    # Arrange — first an HTML cycle
     await scraper_instance.set_content(SAMPLE_HTML_FULL)
     assert scraper_instance._data is not None
     assert scraper_instance._soup is not None
@@ -196,6 +200,18 @@ async def test_scraper_reset_clears_content(hass: HomeAssistant, scraper_instanc
     # Assert
     assert scraper_instance._data is None
     assert scraper_instance._soup is None
+    assert scraper_instance._is_json is False
+
+    # Arrange — now a JSON cycle
+    await scraper_instance.set_content(SAMPLE_JSON_SIMPLE)
+    assert scraper_instance._is_json is True
+
+    # Act
+    scraper_instance.reset()
+
+    # Assert
+    assert scraper_instance._data is None
+    assert scraper_instance._is_json is False
 
 
 @pytest.mark.integration
@@ -257,6 +273,109 @@ async def test_scraper_formatted_content_prettifies_html(
     assert "Test" in formatted
     # Verify it's actually formatted (has indentation)
     assert "  " in formatted  # Multiple spaces indicate indentation
+
+
+# ============================================================================
+# JSON-specific scraper tests
+# ============================================================================
+
+
+@pytest.mark.integration
+@pytest.mark.async_test
+@pytest.mark.timeout(5)
+async def test_scraper_formatted_content_pretty_prints_json(
+    hass: HomeAssistant, scraper_instance
+):
+    """Test that formatted_content returns pretty-printed JSON for JSON responses."""
+    await scraper_instance.set_content(SAMPLE_JSON_NESTED)
+
+    formatted = scraper_instance.formatted_content
+
+    # Pretty-printed JSON has newlines, indentation, and quoted keys
+    assert "\n" in formatted
+    assert '"user"' in formatted
+    # 2-space indent (json.dumps indent=2)
+    assert "\n  " in formatted
+
+
+@pytest.mark.integration
+@pytest.mark.async_test
+@pytest.mark.timeout(5)
+async def test_scraper_handles_malformed_json_softly(
+    hass: HomeAssistant, scraper_instance
+):
+    """Test that malformed JSON soft-fails: detection succeeds, no exception, raw data preserved."""
+    # Act — should not raise
+    await scraper_instance.set_content(SAMPLE_JSON_INVALID)
+
+    # Assert state
+    assert scraper_instance._is_json is True
+    assert scraper_instance._data == SAMPLE_JSON_INVALID
+    # formatted_content falls back to raw when pretty-print fails
+    assert scraper_instance.formatted_content == SAMPLE_JSON_INVALID
+
+    # And select-style scraping still raises the JSON error
+    selector = Selector(hass, {"select": Template(".x", hass), "extract": "text"})
+    with pytest.raises(
+        ValueError,
+        match="JSON cannot be scraped",
+    ):
+        scraper_instance.scrape(selector, "test_sensor")
+
+
+@pytest.mark.integration
+@pytest.mark.async_test
+@pytest.mark.timeout(5)
+async def test_scraper_handles_recursion_error_softly(
+    hass: HomeAssistant, scraper_instance
+):
+    """Pathologically nested JSON (RecursionError) also soft-fails in formatted_content."""
+    # 10000 levels of nesting reliably triggers RecursionError on CPython 3.13
+    # while remaining a syntactically valid JSON-shaped string.
+    deeply_nested = "[" * 10000 + "]" * 10000
+
+    await scraper_instance.set_content(deeply_nested)
+
+    assert scraper_instance._is_json is True
+    assert scraper_instance._data == deeply_nested
+    # formatted_content falls back to raw on RecursionError
+    assert scraper_instance.formatted_content == deeply_nested
+
+
+@pytest.mark.integration
+@pytest.mark.async_test
+@pytest.mark.timeout(5)
+async def test_scraper_json_value_template_still_works(
+    hass: HomeAssistant, scraper_instance
+):
+    """Backwards-compat: value_template against JSON (canonical HA pattern) still works."""
+    await scraper_instance.set_content(SAMPLE_JSON_SIMPLE)
+
+    selector = Selector(
+        hass,
+        {"value_template": Template("{{ value_json.name }}", hass)},
+    )
+
+    value = scraper_instance.scrape(selector, "test_sensor")
+
+    assert value == "John"
+
+
+@pytest.mark.integration
+@pytest.mark.async_test
+@pytest.mark.timeout(5)
+async def test_scraper_json_file_logging_uses_page_json(hass: HomeAssistant):
+    """Test that JSON content is logged to page_json.txt (not page_soup.txt)."""
+    file_manager = MagicMock()
+    scraper = Scraper("test_scraper", hass, file_manager, "lxml", DEFAULT_SEPARATOR)
+
+    await scraper.set_content(SAMPLE_JSON_SIMPLE)
+
+    file_manager.write.assert_called_once()
+    filename, content = file_manager.write.call_args.args
+    assert filename == "page_json.txt"
+    # Content is the pretty-printed form
+    assert '"name": "John"' in content
 
 
 # ============================================================================

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -327,19 +327,24 @@ async def test_scraper_handles_malformed_json_softly(
 @pytest.mark.async_test
 @pytest.mark.timeout(5)
 async def test_scraper_handles_recursion_error_softly(
-    hass: HomeAssistant, scraper_instance
+    hass: HomeAssistant, scraper_instance, monkeypatch
 ):
-    """Pathologically nested JSON (RecursionError) also soft-fails in formatted_content."""
-    # 10000 levels of nesting reliably triggers RecursionError on CPython 3.13
-    # while remaining a syntactically valid JSON-shaped string.
-    deeply_nested = "[" * 10000 + "]" * 10000
-
-    await scraper_instance.set_content(deeply_nested)
-
+    """A JSON parse that raises RecursionError soft-fails in formatted_content."""
+    # Triggering a real RecursionError depends on sys.getrecursionlimit(), which
+    # varies across environments. Simulate the failure mode directly so the test
+    # is deterministic and doesn't produce huge debug output on CI.
+    await scraper_instance.set_content(SAMPLE_JSON_SIMPLE)
     assert scraper_instance._is_json is True
-    assert scraper_instance._data == deeply_nested
+
+    def boom(*_args, **_kwargs):
+        raise RecursionError("simulated deeply-nested JSON")
+
+    monkeypatch.setattr(
+        "custom_components.multiscrape.scraper.json.loads", boom
+    )
+
     # formatted_content falls back to raw on RecursionError
-    assert scraper_instance.formatted_content == deeply_nested
+    assert scraper_instance.formatted_content == SAMPLE_JSON_SIMPLE
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
- Renames `JsonDetector` to `JsonParser`. The old class was misleadingly named — its `parse()` returned `None`. The new `JsonParser.parse()` actually returns the `dict | list`.
- Adds JSON pretty-printing to `page_json.txt` when `log_response` is enabled, alongside the existing `page_soup.txt` path for HTML. `formatted_content` parses on demand and falls back to raw text on `JSONDecodeError` / `RecursionError`.
- No parsed structure is stored on the Scraper; the only side of the codebase that pays the parse cost is the file-logging path (or the `get_content` service when explicitly invoked). `value_template` / `value_json` remains the canonical extraction path via HA's `async_render_with_possible_json_value`.

Groundwork toward #555 (native JSON API support). The JSONPath extractor portion of #555 is intentionally not in this PR.

## Test plan
- [x] `pytest tests/` — 465 tests pass
- [ ] Manual: enable `log_response: true` on a JSON endpoint and verify `page_json.txt` contains pretty-printed JSON
- [ ] Manual: existing `value_template: "{{ value_json.x }}"` configs continue to work unchanged
- [ ] Manual: malformed-JSON response (e.g. truncated) still flows through without raising; raw text ends up in `page_json.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Proper JSON parsing with pretty-printed output for clearer results.
  * JSON responses are written to dedicated log output for easier review.
  * Templates and value extraction now work with JSON responses.

* **Bug Fixes**
  * Graceful fallback for malformed or deeply-nested JSON to preserve raw content.
  * JSON content is no longer treated like HTML, avoiding incorrect parsing.

* **Documentation**
  * README content and formatting updated for clarity.

* **Tests**
  * Test coverage expanded for JSON handling and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/danieldotnl/ha-multiscrape/pull/579)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->