### PR TITLE
Fix blocking SSL cert load on event loop (#578)

### DIFF
--- a/custom_components/multiscrape/http_session.py
+++ b/custom_components/multiscrape/http_session.py
@@ -12,6 +12,7 @@ from homeassistant.const import (CONF_AUTHENTICATION, CONF_HEADERS,
                                  CONF_TIMEOUT, CONF_USERNAME, CONF_VERIFY_SSL,
                                  HTTP_DIGEST_AUTHENTICATION)
 from homeassistant.core import HomeAssistant
+from homeassistant.util.ssl import client_context, create_no_verify_ssl_context
 
 from .const import (CONF_FORM_INPUT, CONF_FORM_INPUT_FILTER,
                     CONF_FORM_RESUBMIT_ERROR, CONF_FORM_SELECT,
@@ -68,9 +69,13 @@ class HttpSession:
         self._file_manager = file_manager
         self._form_authenticator = form_authenticator
 
-        # Create dedicated httpx client with its own cookie jar
+        # Create dedicated httpx client with its own cookie jar.
+        # Use HA's pre-warmed cached SSL context so CA certs are never loaded
+        # on the event loop (homeassistant.util.ssl pre-warms the cache at
+        # import time precisely to avoid blocking I/O here).
+        ssl_ctx = client_context() if http_config.verify_ssl else create_no_verify_ssl_context()
         self._client = httpx.AsyncClient(
-            verify=http_config.verify_ssl,
+            verify=ssl_ctx,
             timeout=http_config.timeout,
             follow_redirects=True,
         )

--- a/tests/test_http_session.py
+++ b/tests/test_http_session.py
@@ -1,6 +1,9 @@
 """Tests for the unified HttpSession class."""
 
 
+import ssl
+from unittest.mock import patch
+
 import httpx
 import pytest
 import respx
@@ -118,6 +121,32 @@ FORM_PAGE_NO_ACTION = """
 </body>
 </html>
 """
+
+
+# ============================================================================
+# Regression: issue #578 — blocking SSL cert load on event loop
+# ============================================================================
+
+
+@pytest.mark.parametrize("verify_ssl", [True, False])
+def test_init_does_not_load_verify_locations(hass: HomeAssistant, verify_ssl):
+    """HttpSession must not call ssl.SSLContext.load_verify_locations during init.
+
+    Regression guard for issue #578: constructing httpx.AsyncClient(verify=bool)
+    triggers a synchronous CA-bundle load on the event loop. We avoid this by
+    passing a pre-built (and pre-warmed) ssl.SSLContext from HA's util.ssl.
+    """
+    with patch.object(
+        ssl.SSLContext, "load_verify_locations"
+    ) as mock_load:
+        HttpSession(
+            config_name="test_ssl",
+            hass=hass,
+            http_config=make_http_config(verify_ssl=verify_ssl),
+            file_manager=None,
+        )
+
+    mock_load.assert_not_called()
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- Closes #578 — HA blocking-call detector flagged `load_verify_locations` at scraper setup.
- Pass HA's pre-warmed cached `ssl.SSLContext` (from `homeassistant.util.ssl`) into `httpx.AsyncClient(verify=...)` instead of letting httpx build a fresh context synchronously, which read certifi's CA bundle from disk on the event loop.
- Preserves the v9 per-scraper cookie isolation (still a dedicated `httpx.AsyncClient` per `HttpSession`). Going back to `get_async_client` would have re-broken that.

## Why this is a regression in v9.0.0

v8.0.5 used `homeassistant.helpers.httpx_client.get_async_client(hass, verify_ssl)`, which returns HA's shared client built on the cached SSL context — no blocking call ever fired. v9.0.0 commit `8ee795a` replaced the shared helper with direct `httpx.AsyncClient(verify=bool, ...)` to give each scraper its own cookie jar, which reintroduced the cert load on the event loop.

`homeassistant.util.ssl` pre-warms verifying and no-verify SSL contexts at module-load time precisely so integrations can grab a ready-to-use context without blocking I/O. We use those directly; we don't go through `create_async_httpx_client` because it wraps `aclose` with `warn_use`, which would warn on every `HttpSession.async_close()`.

## Test plan

- [x] All 467 existing tests pass (`pytest tests/`)
- [x] New regression test `test_init_does_not_load_verify_locations` (parametrized over `verify_ssl=True/False`) asserts `ssl.SSLContext.load_verify_locations` is not invoked during `HttpSession.__init__`
- [ ] Manual: load with the reporter's YAML in a HA dev instance and confirm the `Detected blocking call to load_verify_locations` warning no longer fires at startup or during `multiscrape.scrape` service calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Technical Improvements**
  * Enhanced SSL certificate verification handling in HTTP sessions for better integration with security infrastructure.

* **Tests**
  * Added regression tests for HTTP session SSL configuration to ensure reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/danieldotnl/ha-multiscrape/pull/580)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->