### PR TITLE
Don't restore unavailable/unknown sentinel as native value

### DIFF
--- a/custom_components/multiscrape/entity.py
+++ b/custom_components/multiscrape/entity.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 from abc import abstractmethod
 
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -97,7 +98,8 @@ class MultiscrapeEntity(CoordinatorEntity[MultiscrapeDataUpdateCoordinator], Res
         if not (state := await self.async_get_last_state()):
             return
         _LOGGER.debug("%s # %s # Restoring previous state: %s", self.scraper.name, self._name, state.state)
-        self._attr_native_value = state.state
+        if state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+            self._attr_native_value = state.state
 
         for name in self._attribute_selectors:
             if state.attributes.get(name) is not None:

--- a/custom_components/multiscrape/manifest.json
+++ b/custom_components/multiscrape/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/danieldotnl/ha-multiscrape/issues",
   "requirements": ["lxml>=4.9.1", "beautifulsoup4>=4.12.2"],
-  "version": "9.0.2"
+  "version": "9.0.3"
 }

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -3,7 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_NAME, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.template import Template
 
@@ -552,6 +552,30 @@ async def test_async_added_to_hass_restores_state_and_attributes(
     # Assert
     assert sensor._attr_native_value == "42.0"
     assert sensor._attr_extra_state_attributes["test_attr"] == "saved_value"
+
+
+@pytest.mark.integration
+@pytest.mark.async_test
+@pytest.mark.timeout(10)
+@pytest.mark.parametrize("sentinel", [STATE_UNAVAILABLE, STATE_UNKNOWN])
+async def test_async_added_to_hass_does_not_restore_sentinel_states(
+    hass: HomeAssistant, coordinator, scraper, sentinel
+):
+    """Sentinel states must not be restored as a native value.
+
+    A numeric sensor (unit but no device/state class) would otherwise
+    crash on add_to_platform_finish trying to float('unavailable').
+    """
+    sensor = _create_sensor(hass, coordinator, scraper)
+    initial_value = sensor._attr_native_value
+
+    mock_state = State("sensor.test", sentinel)
+    with patch.object(sensor, "async_get_last_state", new=AsyncMock(return_value=mock_state)):
+        await sensor.async_added_to_hass()
+
+    # Assert - sentinel not restored, value left at its default
+    assert sensor._attr_native_value == initial_value
+    assert sensor._attr_native_value not in (STATE_UNAVAILABLE, STATE_UNKNOWN)
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Problem

After upgrading HA core, numeric multiscrape sensors crash on startup:

```
ValueError: could not convert string to float: 'unavailable'
...
ValueError: Sensor sensor.X has device class 'None', state class 'None' unit '...' and suggested precision 'None' thus indicating it has a numeric value; however, it has the non-numeric value: 'unavailable'
```

## Root cause

`MultiscrapeEntity.async_added_to_hass` restored `state.state` unconditionally. If HA was last shut down while the sensor was unavailable, the literal sentinel string `'unavailable'` (or `'unknown'`) was restored as the sensor's native value.

Recent HA core promoted the "numeric-indicating sensor holds a non-numeric value" check from a warning to a raised `ValueError` in `SensorEntity.state`. A sensor with a `unit_of_measurement` but no `device_class`/`state_class` is treated as numeric, so restoring `'unavailable'` now crashes entity setup during `add_to_platform_finish`.

## Fix

Guard the restore against `STATE_UNAVAILABLE`/`STATE_UNKNOWN` in the base entity, so `sensor`, `binary_sensor`, and `button` all start as unknown until the first scrape. Added a parametrized regression test and bumped the version to 9.0.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved state restoration so entities no longer recover as `unavailable` or `unknown` after restart.
  * Kept the existing sensor value when a valid previous value cannot be restored, making startup behavior more reliable.

* **Chores**
  * Updated the integration version to `9.0.3`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->