### PR TITLE
fix: restore icon on startup to avoid a spurious state_changed trigger

### DIFF
--- a/custom_components/multiscrape/entity.py
+++ b/custom_components/multiscrape/entity.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from abc import abstractmethod
 
-from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.const import ATTR_ICON, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -105,6 +105,13 @@ class MultiscrapeEntity(CoordinatorEntity[MultiscrapeDataUpdateCoordinator], Res
             if state.attributes.get(name) is not None:
                 _LOGGER.debug("%s # %s # Restoring attribute `%s` with value: %s", self.scraper.name, self._name, name, state.attributes[name])
                 self._attr_extra_state_attributes[name] = state.attributes[name]
+
+        if self._icon_template and (icon := state.attributes.get(ATTR_ICON)) is not None:
+            # Otherwise the entity is written with no icon on startup, and the
+            # first real coordinator update sets it seconds later -- a
+            # spurious attribute-only state change that a bare `platform:
+            # state` trigger (no to/from) fires on (#437).
+            self._attr_icon = icon
 
 
     @callback

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -3,7 +3,8 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from homeassistant.const import CONF_NAME, STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.const import (ATTR_ICON, CONF_NAME, STATE_UNAVAILABLE,
+                                 STATE_UNKNOWN)
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.template import Template
 
@@ -552,6 +553,45 @@ async def test_async_added_to_hass_restores_state_and_attributes(
     # Assert
     assert sensor._attr_native_value == "42.0"
     assert sensor._attr_extra_state_attributes["test_attr"] == "saved_value"
+
+
+@pytest.mark.integration
+@pytest.mark.async_test
+@pytest.mark.timeout(10)
+async def test_async_added_to_hass_restores_icon(hass: HomeAssistant, coordinator, scraper):
+    """Restoring on startup must also restore a previously rendered icon (#437).
+
+    Without this, the entity is briefly written to HA with no icon on
+    startup, and the first real coordinator update -- seconds later --
+    sets it, producing a spurious attribute-only state change that a bare
+    `platform: state` trigger (no `to`/`from`) fires on.
+    """
+    icon_template = Template("mdi:check", hass)
+    sensor = _create_sensor(hass, coordinator, scraper, icon_template=icon_template)
+
+    mock_state = State("sensor.test", "42.0", {ATTR_ICON: "mdi:alert"})
+    with patch.object(sensor, "async_get_last_state", new=AsyncMock(return_value=mock_state)):
+        await sensor.async_added_to_hass()
+
+    # Assert
+    assert sensor.icon == "mdi:alert"
+
+
+@pytest.mark.integration
+@pytest.mark.async_test
+@pytest.mark.timeout(10)
+async def test_async_added_to_hass_without_icon_template_does_not_set_icon(
+    hass: HomeAssistant, coordinator, scraper
+):
+    """An entity with no icon_template configured should not gain one from restore."""
+    sensor = _create_sensor(hass, coordinator, scraper)
+
+    mock_state = State("sensor.test", "42.0", {ATTR_ICON: "mdi:alert"})
+    with patch.object(sensor, "async_get_last_state", new=AsyncMock(return_value=mock_state)):
+        await sensor.async_added_to_hass()
+
+    # Assert
+    assert sensor.icon is None
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

Closes #437. `async_added_to_hass()` restores `_attr_native_value` and the tracked `_attribute_selectors` from the last known state, but never the icon rendered by an `icon_template`. `_set_icon()` is only called from `_update_sensor()`, which only runs inside `_handle_coordinator_update()` -- never during restore.

The result on every HA restart: the entity is first written with no icon (restore), then the coordinator's first real update sets the icon a few seconds later -- an attribute-only change (same `native_value`, different `icon`) that a bare `platform: state` trigger (no `to`/`from`) fires on. This matches the reports from @parautenbach and @Broekman, and @parautenbach's own finding that it only happens "right at startup" and traces to the #417 restore-on-startup change.

Fix: in `async_added_to_hass()`, if the entity has an `icon_template` and the last state carried an `icon` attribute, restore it into `_attr_icon` -- same pattern already used for the other restored attributes. Entities without an `icon_template` are unaffected (verified by a dedicated test).

## Testing

- Added `test_async_added_to_hass_restores_icon`, reproducing the bug: fails on current `master` (`sensor.icon` is `None` instead of the restored value), passes with the fix.
- Added `test_async_added_to_hass_without_icon_template_does_not_set_icon` to guard the "no icon_template configured" case stays `None`.
- Mutation-tested: reverted the fix and confirmed exactly the new `test_async_added_to_hass_restores_icon` test fails, all 17 others (including the new guard test) unaffected.
- Full suite: 471 passed.
- `ruff check` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored saved entity icons when an icon template is configured.
  * Prevented saved icons from being applied when no icon template is configured.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->