### PR TITLE
Bump version to 9.0.4

### DIFF
--- a/custom_components/multiscrape/manifest.json
+++ b/custom_components/multiscrape/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/danieldotnl/ha-multiscrape/issues",
   "requirements": ["lxml>=4.9.1", "beautifulsoup4>=4.12.2"],
-  "version": "9.0.3"
+  "version": "9.0.4"
 }


### PR DESCRIPTION
Version bump for the v9.0.4 release.

Includes #605 (restore icon on startup, closes #437) plus dependency updates since v9.0.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the integration to version 9.0.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->